### PR TITLE
fix(retrievcer): adding leader election

### DIFF
--- a/cmd/retriever/clubs_retriever.go
+++ b/cmd/retriever/clubs_retriever.go
@@ -24,7 +24,13 @@ const (
 	clubSearchURL = "https://www.englandgolf.org/api/clubs/ClubSearch"
 )
 
-func clubsTask(l *slog.Logger, keydb func() goredis.Pool, wp func() workerpool.Pool) web.AsyncTaskFunc {
+func clubsTask(
+	l *slog.Logger,
+	keydb func() goredis.Pool,
+	wp func() workerpool.Pool,
+	isLeader func() bool,
+	leaderChange <-chan struct{},
+) web.AsyncTaskFunc {
 	return func(ctx context.Context) error {
 		// Pick a random time between 15 - 60 minutes to run the task
 		intervalNum, err := rand.Int(rand.Reader, big.NewInt(45))
@@ -35,16 +41,29 @@ func clubsTask(l *slog.Logger, keydb func() goredis.Pool, wp func() workerpool.P
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
-		l.Info("ticker started", slog.String(logKeys.KeyInterval, interval.String()))
-
 		for {
 			select {
 			case <-ctx.Done():
 				return nil
-			case <-ticker.C:
-				l.Debug("ticker ticked")
-				if err := clubWorker(ctx, l, keydb(), wp()); err != nil {
-					return fmt.Errorf("failed to run club worker: %w", err)
+			case <-leaderChange:
+				if !isLeader() {
+					l.Info("not leader, waiting for leader change")
+					continue
+				}
+
+				l.Info("ticker started", slog.String(logKeys.KeyInterval, interval.String()))
+
+				for {
+					select {
+					case <-ctx.Done():
+						return nil
+					case <-ticker.C:
+						l.Debug("ticker ticked")
+						if err := clubWorker(ctx, l, keydb(), wp()); err != nil {
+							l.Error("failed to run club worker", slog.String(logging.KeyError, err.Error()))
+							continue
+						}
+					}
 				}
 			}
 		}

--- a/cmd/retriever/main.go
+++ b/cmd/retriever/main.go
@@ -29,7 +29,7 @@ func main() {
 		web.WithRedisPool(),
 		web.WithWorkerPool(),
 		web.WithLeaderElection(appName),
-		web.WithIndefiniteAsyncTask("clubs-fetcher", clubsTask(l, a.RedisPool, a.WorkerPool)),
+		web.WithIndefiniteAsyncTask("clubs-fetcher", clubsTask(l, a.RedisPool, a.WorkerPool, a.IsLeader, a.LeaderChange())),
 	); err != nil {
 		l.Error("failed to start web app", slog.String(logging.KeyError, err.Error()))
 		os.Exit(1)


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to the `cmd/retriever` package, specifically enhancing the `clubs_retriever` functionality to support leader election and improve error handling.

Enhancements to leader election:

* [`cmd/retriever/clubs_retriever.go`](diffhunk://#diff-fc91dcff9ca307adf65132c11e87fe2c7e8a901f7e602288eb765ce97d6a0edbL27-R33): Modified the `clubsTask` function to include `isLeader` and `leaderChange` parameters, allowing the task to check leadership status and respond to leader changes. [[1]](diffhunk://#diff-fc91dcff9ca307adf65132c11e87fe2c7e8a901f7e602288eb765ce97d6a0edbL27-R33) [[2]](diffhunk://#diff-fc91dcff9ca307adf65132c11e87fe2c7e8a901f7e602288eb765ce97d6a0edbR44-R53)
* [`cmd/retriever/main.go`](diffhunk://#diff-528514028449724948e21a5f0042cd49a7282fce96574ad896c3c67e6f60d455L32-R32): Updated the call to `clubsTask` to pass the new `isLeader` and `leaderChange` parameters.

Improvements to error handling:

* [`cmd/retriever/clubs_retriever.go`](diffhunk://#diff-fc91dcff9ca307adf65132c11e87fe2c7e8a901f7e602288eb765ce97d6a0edbL47-R66): Changed the error handling within the `ticker` loop to log errors and continue execution instead of returning an error immediately.