### PR TITLE
fix(clubs): removing unique naming constraint on the db

### DIFF
--- a/cmd/retriever/clubs_retriever.go
+++ b/cmd/retriever/clubs_retriever.go
@@ -62,10 +62,11 @@ func (a *App) clubsTask() web.AsyncTaskFunc {
 						}
 					}
 
-					if !a.base.IsLeader() {
-						a.base.Logger().Info("not leader, waiting for leader change")
-						break
+					if a.base.IsLeader() {
+						continue
 					}
+					a.base.Logger().Info("not leader, waiting for leader change")
+					break
 				}
 			}
 		}

--- a/cmd/retriever/clubs_retriever.go
+++ b/cmd/retriever/clubs_retriever.go
@@ -52,12 +52,19 @@ func (a *App) clubsTask() web.AsyncTaskFunc {
 					select {
 					case <-ctx.Done():
 						return
+					case <-a.base.LeaderChange():
+						// Do nothing as this logic is handled in the outer loop
 					case <-ticker.C:
 						a.base.Logger().Debug("ticker ticked")
 						if err := clubWorker(ctx, a.base.Logger(), a.base.NatsJetStream(), a.base.WorkerPool()); err != nil {
 							a.base.Logger().Error("failed to run club worker", slog.String(logging.KeyError, err.Error()))
 							continue
 						}
+					}
+
+					if !a.base.IsLeader() {
+						a.base.Logger().Info("not leader, waiting for leader change")
+						break
 					}
 				}
 			}

--- a/database/migrations/20250325101846_club_init.up.sql
+++ b/database/migrations/20250325101846_club_init.up.sql
@@ -7,7 +7,6 @@ create table club
     address3    varchar(255) not null,
     address4    varchar(255) not null,
     postal_code varchar(8)   not null,
-    primary key (id),
-    unique (name)
+    primary key (id)
 );
 

--- a/pkg/models/club.xo.go
+++ b/pkg/models/club.xo.go
@@ -272,26 +272,6 @@ func (m *Club) Patch(db DB, newT *Club) error {
 	return nil
 }
 
-// ClubByName retrieves a row from 'club' as a *Club.
-//
-// Generated from index ” of type 'unique'.
-func ClubByName(db DB, name string) (*Club, error) {
-	t := prometheus.NewTimer(DatabaseLatency.WithLabelValues("get_" + ClubTableName + "_by_name"))
-	defer t.ObserveDuration()
-
-	const sqlstr = "SELECT `id`, `name`, `address1`, `address2`, `address3`, `address4`, `postal_code` " +
-		"FROM club " +
-		"WHERE `name` = ?"
-
-	DBLog(sqlstr, name)
-	var m Club
-	if err := db.Get(&m, sqlstr, name); err != nil {
-		return nil, err
-	}
-
-	return &m, nil
-}
-
 // GetAllClubs retrieves all rows from 'club' as a slice of Club.
 //
 // Generated from table 'club'.

--- a/pkg/models/schemas/club.sql
+++ b/pkg/models/schemas/club.sql
@@ -7,7 +7,6 @@ create table club
     address3    varchar(255) not null,
     address4    varchar(255) not null,
     postal_code varchar(8)   not null,
-    primary key (id),
-    unique (name)
+    primary key (id)
 );
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes related to the handling of clubs in the application, including modifications to the database schema, removal of a database query function, and updates to the task handling logic.

### Database Schema Changes:
* `database/migrations/20250325101846_club_init.up.sql` and `pkg/models/schemas/club.sql`: Removed the unique constraint on the `name` column in the `club` table.

### Codebase Simplification:
* [`pkg/models/club.xo.go`](diffhunk://#diff-cf6531ea2942053202c55a2009e4c9fca4db3ce3fe20a230cb82932b7aefdea3L275-L294): Removed the `ClubByName` function, which retrieved a club by its name from the database.

### Task Handling Logic:
* [`cmd/retriever/clubs_retriever.go`](diffhunk://#diff-fc91dcff9ca307adf65132c11e87fe2c7e8a901f7e602288eb765ce97d6a0edbR55-R68): Added a check for leader change within the `clubsTask` function and included a log message when the instance is not the leader.