### PR TITLE
feat(health): adding app health checks

### DIFF
--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jacobbrewer1/golf-data/pkg/services/processor/domain"
 	"github.com/jacobbrewer1/web"
 	"github.com/jacobbrewer1/web/logging"
+	"github.com/nats-io/nats.go"
 )
 
 const (
@@ -53,6 +54,27 @@ func (a *App) Start() error {
 			return nil
 		}),
 		web.WithIndefiniteAsyncTask("clubs-processes", a.Clubs),
+		web.WithHealthCheck(map[string]web.HealthCheckFunc{
+			"nats": func(ctx context.Context) error {
+				status := a.base.NatsClient().Status()
+				switch status {
+				case nats.CONNECTED,
+					nats.CONNECTING,
+					nats.RECONNECTING,
+					nats.DRAINING_SUBS,
+					nats.DRAINING_PUBS:
+					return nil
+				default:
+					return fmt.Errorf("nats status: %s", status)
+				}
+			},
+			"database": func(ctx context.Context) error {
+				if err := a.base.DBConn().PingContext(ctx); err != nil {
+					return fmt.Errorf("failed to ping database: %w", err)
+				}
+				return nil
+			},
+		}),
 	); err != nil {
 		a.base.Logger().Error("failed to start web app", slog.String(logging.KeyError, err.Error()))
 		os.Exit(1)

--- a/cmd/retriever/main.go
+++ b/cmd/retriever/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 	"os"
 
 	"github.com/jacobbrewer1/web"
 	"github.com/jacobbrewer1/web/logging"
+	"github.com/nats-io/nats.go"
 )
 
 const (
@@ -35,6 +38,27 @@ func (a *App) Start() error {
 		web.WithInClusterNatsClient(),
 		web.WithNatsJetStream("golf-data", []string{"clubs"}),
 		web.WithIndefiniteAsyncTask("clubs-fetcher", a.clubsTask()),
+		web.WithHealthCheck(map[string]web.HealthCheckFunc{
+			"kube": func(ctx context.Context) error {
+				if _, err := a.base.KubeClient().Discovery().ServerVersion(); err != nil {
+					return fmt.Errorf("failed to get server version: %w", err)
+				}
+				return nil
+			},
+			"nats": func(ctx context.Context) error {
+				status := a.base.NatsClient().Status()
+				switch status {
+				case nats.CONNECTED,
+					nats.CONNECTING,
+					nats.RECONNECTING,
+					nats.DRAINING_SUBS,
+					nats.DRAINING_PUBS:
+					return nil
+				default:
+					return fmt.Errorf("nats status: %s", status)
+				}
+			},
+		}),
 	); err != nil {
 		a.base.Logger().Error("failed to start web app", slog.String(logging.KeyError, err.Error()))
 		os.Exit(1)


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to add health checks for NATS and database connections in the `cmd/processor` and `cmd/retriever` applications. Additionally, it includes necessary imports and context handling for these health checks.

Health checks:

* [`cmd/processor/main.go`](diffhunk://#diff-7afb37135e307b512d560f88055928a906f18a3a6e528f208452d1e1bbc86449R57-R77): Added health checks for NATS and database connections in the `Start` function.
* [`cmd/retriever/main.go`](diffhunk://#diff-528514028449724948e21a5f0042cd49a7282fce96574ad896c3c67e6f60d455R41-R61): Added health checks for NATS and Kubernetes in the `Start` function.

Imports:

* [`cmd/processor/main.go`](diffhunk://#diff-7afb37135e307b512d560f88055928a906f18a3a6e528f208452d1e1bbc86449R14): Added import for `nats.go` package.
* [`cmd/retriever/main.go`](diffhunk://#diff-528514028449724948e21a5f0042cd49a7282fce96574ad896c3c67e6f60d455R4-R11): Added imports for `context`, `fmt`, and `nats.go` packages.