### PR TITLE
fix(processor): correcting column name for marker id

### DIFF
--- a/pkg/repositories/processor/filters/hole_marker_id.go
+++ b/pkg/repositories/processor/filters/hole_marker_id.go
@@ -13,5 +13,5 @@ func NewHoleMarkerId(markerId int) patcher.Wherer {
 }
 
 func (h *holeMarkerId) Where() (sqlStr string, args []any) {
-	return "t.marker_id = ?", []any{h.markerId}
+	return "t.details_id = ?", []any{h.markerId}
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a minor change to the `pkg/repositories/processor/filters/hole_marker_id.go` file. The change modifies the SQL query in the `Where` method to use `details_id` instead of `marker_id`.

* [`pkg/repositories/processor/filters/hole_marker_id.go`](diffhunk://#diff-15acca8e3e327f3a845f740cccae863657ce6e26c42e2936a7cd1537a58eb898L16-R16): Modified the `Where` method to return "t.details_id = ?" instead of "t.marker_id = ?"