### PR TITLE
feat(templates): updating the server templates

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,6 @@ linters:
     - tparallel
   settings:
     goconst:
-      ignore-strings: ""
       ignore-calls: true
     gocritic:
       enable-all: true

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -15,11 +15,9 @@ import (
 	apiSvc "github.com/jacobbrewer1/golf-data/pkg/services/api"
 	"github.com/jacobbrewer1/golf-data/pkg/services/api/domain"
 	"github.com/jacobbrewer1/uhttp"
-	"github.com/jacobbrewer1/vaulty"
 	"github.com/jacobbrewer1/web"
 	"github.com/jacobbrewer1/web/health"
 	"github.com/jacobbrewer1/web/logging"
-	"github.com/spf13/viper"
 )
 
 const (
@@ -31,23 +29,6 @@ func main() {
 		logging.WithDefaultLogger(),
 		logging.WithAppName(appName),
 	)
-
-	web.VaultClient = func(ctx context.Context, l *slog.Logger, v *viper.Viper) (vaulty.Client, error) {
-		addr := v.GetString("vault.address")
-
-		vc, err := vaulty.NewClient(
-			vaulty.WithContext(ctx),
-			vaulty.WithAddr(addr),
-			vaulty.WithTokenAuth(v.GetString("vault.token")),
-			vaulty.WithKvv2Mount(v.GetString("vault.kvv2_mount")),
-			vaulty.WithLogger(l),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("error creating vault client: %w", err)
-		}
-
-		return vc, nil
-	}
 
 	a, err := web.NewApp(l)
 	if err != nil {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -15,9 +15,11 @@ import (
 	apiSvc "github.com/jacobbrewer1/golf-data/pkg/services/api"
 	"github.com/jacobbrewer1/golf-data/pkg/services/api/domain"
 	"github.com/jacobbrewer1/uhttp"
+	"github.com/jacobbrewer1/vaulty"
 	"github.com/jacobbrewer1/web"
 	"github.com/jacobbrewer1/web/health"
 	"github.com/jacobbrewer1/web/logging"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -29,6 +31,23 @@ func main() {
 		logging.WithDefaultLogger(),
 		logging.WithAppName(appName),
 	)
+
+	web.VaultClient = func(ctx context.Context, l *slog.Logger, v *viper.Viper) (vaulty.Client, error) {
+		addr := v.GetString("vault.address")
+
+		vc, err := vaulty.NewClient(
+			vaulty.WithContext(ctx),
+			vaulty.WithAddr(addr),
+			vaulty.WithTokenAuth(v.GetString("vault.token")),
+			vaulty.WithKvv2Mount(v.GetString("vault.kvv2_mount")),
+			vaulty.WithLogger(l),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("error creating vault client: %w", err)
+		}
+
+		return vc, nil
+	}
 
 	a, err := web.NewApp(l)
 	if err != nil {

--- a/pkg/apis/specs/api/server.go
+++ b/pkg/apis/specs/api/server.go
@@ -194,10 +194,10 @@ func (siw *ServerInterfaceWrapper) GetClubs(w http.ResponseWriter, r *http.Reque
 	)
 
 	ctx := r.Context()
-	cw := uhttp.NewResponseWriter(w,
+	w = uhttp.NewResponseWriter(w,
 		uhttp.WithDefaultStatusCode(http.StatusOK),
 		uhttp.WithDefaultHeader(uhttp.HeaderRequestID, uhttp.RequestIDFromContext(ctx)),
-		uhttp.WithDefaultHeader(uhttp.HeaderContentType, uhttp.ContentTypeJSON),
+		uhttp.WithDefaultHeader(uhttp.HeaderContentType, "application/json; charset=utf-8"),
 	)
 
 	// Parameter object where we will unmarshal all parameters from the context
@@ -212,7 +212,7 @@ func (siw *ServerInterfaceWrapper) GetClubs(w http.ResponseWriter, r *http.Reque
 		r.URL.Query(),
 		&params.Limit,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "limit", Err: err})
 		return
 	}
 
@@ -225,7 +225,7 @@ func (siw *ServerInterfaceWrapper) GetClubs(w http.ResponseWriter, r *http.Reque
 		r.URL.Query(),
 		&params.LastVal,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "last_val", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "last_val", Err: err})
 		return
 	}
 
@@ -238,7 +238,7 @@ func (siw *ServerInterfaceWrapper) GetClubs(w http.ResponseWriter, r *http.Reque
 		r.URL.Query(),
 		&params.LastId,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "last_id", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "last_id", Err: err})
 		return
 	}
 
@@ -251,7 +251,7 @@ func (siw *ServerInterfaceWrapper) GetClubs(w http.ResponseWriter, r *http.Reque
 		r.URL.Query(),
 		&params.Offset,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "offset", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "offset", Err: err})
 		return
 	}
 
@@ -264,7 +264,7 @@ func (siw *ServerInterfaceWrapper) GetClubs(w http.ResponseWriter, r *http.Reque
 		r.URL.Query(),
 		&params.SortBy,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "sort_by", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "sort_by", Err: err})
 		return
 	}
 
@@ -277,7 +277,7 @@ func (siw *ServerInterfaceWrapper) GetClubs(w http.ResponseWriter, r *http.Reque
 		r.URL.Query(),
 		&params.SortDir,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "sort_dir", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "sort_dir", Err: err})
 		return
 	}
 
@@ -290,7 +290,7 @@ func (siw *ServerInterfaceWrapper) GetClubs(w http.ResponseWriter, r *http.Reque
 		r.URL.Query(),
 		&params.Name,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "name", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "name", Err: err})
 		return
 	}
 
@@ -315,7 +315,7 @@ func (siw *ServerInterfaceWrapper) GetClubs(w http.ResponseWriter, r *http.Reque
 	// Invoke the callback with all the unmarshalled arguments
 	resp, err := siw.handler.GetClubs(logging.LoggerWithComponent(l, "handler"), r, params)
 	if err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, err)
+		siw.errorHandlerFunc(ctx, l, w, err)
 		return
 	}
 
@@ -323,7 +323,7 @@ func (siw *ServerInterfaceWrapper) GetClubs(w http.ResponseWriter, r *http.Reque
 	w.WriteHeader(200)
 	err = json.NewEncoder(w).Encode(resp)
 	if err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, err)
+		siw.errorHandlerFunc(ctx, l, w, err)
 		return
 	}
 }
@@ -336,10 +336,10 @@ func (siw *ServerInterfaceWrapper) GetCourses(w http.ResponseWriter, r *http.Req
 	)
 
 	ctx := r.Context()
-	cw := uhttp.NewResponseWriter(w,
+	w = uhttp.NewResponseWriter(w,
 		uhttp.WithDefaultStatusCode(http.StatusOK),
 		uhttp.WithDefaultHeader(uhttp.HeaderRequestID, uhttp.RequestIDFromContext(ctx)),
-		uhttp.WithDefaultHeader(uhttp.HeaderContentType, uhttp.ContentTypeJSON),
+		uhttp.WithDefaultHeader(uhttp.HeaderContentType, "application/json; charset=utf-8"),
 	)
 
 	// ------------- Path parameter "club_id" -------------
@@ -351,7 +351,7 @@ func (siw *ServerInterfaceWrapper) GetCourses(w http.ResponseWriter, r *http.Req
 		&clubId,
 		runtime.BindStyledParameterOptions{Explode: false, Required: true},
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "club_id", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "club_id", Err: err})
 		return
 	}
 
@@ -367,7 +367,7 @@ func (siw *ServerInterfaceWrapper) GetCourses(w http.ResponseWriter, r *http.Req
 		r.URL.Query(),
 		&params.Limit,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "limit", Err: err})
 		return
 	}
 
@@ -380,7 +380,7 @@ func (siw *ServerInterfaceWrapper) GetCourses(w http.ResponseWriter, r *http.Req
 		r.URL.Query(),
 		&params.LastVal,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "last_val", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "last_val", Err: err})
 		return
 	}
 
@@ -393,7 +393,7 @@ func (siw *ServerInterfaceWrapper) GetCourses(w http.ResponseWriter, r *http.Req
 		r.URL.Query(),
 		&params.LastId,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "last_id", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "last_id", Err: err})
 		return
 	}
 
@@ -406,7 +406,7 @@ func (siw *ServerInterfaceWrapper) GetCourses(w http.ResponseWriter, r *http.Req
 		r.URL.Query(),
 		&params.Offset,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "offset", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "offset", Err: err})
 		return
 	}
 
@@ -419,7 +419,7 @@ func (siw *ServerInterfaceWrapper) GetCourses(w http.ResponseWriter, r *http.Req
 		r.URL.Query(),
 		&params.SortBy,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "sort_by", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "sort_by", Err: err})
 		return
 	}
 
@@ -432,7 +432,7 @@ func (siw *ServerInterfaceWrapper) GetCourses(w http.ResponseWriter, r *http.Req
 		r.URL.Query(),
 		&params.SortDir,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "sort_dir", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "sort_dir", Err: err})
 		return
 	}
 
@@ -457,7 +457,7 @@ func (siw *ServerInterfaceWrapper) GetCourses(w http.ResponseWriter, r *http.Req
 	// Invoke the callback with all the unmarshalled arguments
 	resp, err := siw.handler.GetCourses(logging.LoggerWithComponent(l, "handler"), r, clubId, params)
 	if err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, err)
+		siw.errorHandlerFunc(ctx, l, w, err)
 		return
 	}
 
@@ -465,7 +465,7 @@ func (siw *ServerInterfaceWrapper) GetCourses(w http.ResponseWriter, r *http.Req
 	w.WriteHeader(200)
 	err = json.NewEncoder(w).Encode(resp)
 	if err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, err)
+		siw.errorHandlerFunc(ctx, l, w, err)
 		return
 	}
 }
@@ -478,10 +478,10 @@ func (siw *ServerInterfaceWrapper) GetMarkers(w http.ResponseWriter, r *http.Req
 	)
 
 	ctx := r.Context()
-	cw := uhttp.NewResponseWriter(w,
+	w = uhttp.NewResponseWriter(w,
 		uhttp.WithDefaultStatusCode(http.StatusOK),
 		uhttp.WithDefaultHeader(uhttp.HeaderRequestID, uhttp.RequestIDFromContext(ctx)),
-		uhttp.WithDefaultHeader(uhttp.HeaderContentType, uhttp.ContentTypeJSON),
+		uhttp.WithDefaultHeader(uhttp.HeaderContentType, "application/json; charset=utf-8"),
 	)
 
 	// ------------- Path parameter "course_id" -------------
@@ -493,7 +493,7 @@ func (siw *ServerInterfaceWrapper) GetMarkers(w http.ResponseWriter, r *http.Req
 		&courseId,
 		runtime.BindStyledParameterOptions{Explode: false, Required: true},
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "course_id", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "course_id", Err: err})
 		return
 	}
 
@@ -509,7 +509,7 @@ func (siw *ServerInterfaceWrapper) GetMarkers(w http.ResponseWriter, r *http.Req
 		r.URL.Query(),
 		&params.Limit,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "limit", Err: err})
 		return
 	}
 
@@ -522,7 +522,7 @@ func (siw *ServerInterfaceWrapper) GetMarkers(w http.ResponseWriter, r *http.Req
 		r.URL.Query(),
 		&params.LastVal,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "last_val", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "last_val", Err: err})
 		return
 	}
 
@@ -535,7 +535,7 @@ func (siw *ServerInterfaceWrapper) GetMarkers(w http.ResponseWriter, r *http.Req
 		r.URL.Query(),
 		&params.LastId,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "last_id", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "last_id", Err: err})
 		return
 	}
 
@@ -548,7 +548,7 @@ func (siw *ServerInterfaceWrapper) GetMarkers(w http.ResponseWriter, r *http.Req
 		r.URL.Query(),
 		&params.Offset,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "offset", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "offset", Err: err})
 		return
 	}
 
@@ -561,7 +561,7 @@ func (siw *ServerInterfaceWrapper) GetMarkers(w http.ResponseWriter, r *http.Req
 		r.URL.Query(),
 		&params.SortBy,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "sort_by", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "sort_by", Err: err})
 		return
 	}
 
@@ -574,7 +574,7 @@ func (siw *ServerInterfaceWrapper) GetMarkers(w http.ResponseWriter, r *http.Req
 		r.URL.Query(),
 		&params.SortDir,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "sort_dir", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "sort_dir", Err: err})
 		return
 	}
 
@@ -599,7 +599,7 @@ func (siw *ServerInterfaceWrapper) GetMarkers(w http.ResponseWriter, r *http.Req
 	// Invoke the callback with all the unmarshalled arguments
 	resp, err := siw.handler.GetMarkers(logging.LoggerWithComponent(l, "handler"), r, courseId, params)
 	if err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, err)
+		siw.errorHandlerFunc(ctx, l, w, err)
 		return
 	}
 
@@ -607,7 +607,7 @@ func (siw *ServerInterfaceWrapper) GetMarkers(w http.ResponseWriter, r *http.Req
 	w.WriteHeader(200)
 	err = json.NewEncoder(w).Encode(resp)
 	if err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, err)
+		siw.errorHandlerFunc(ctx, l, w, err)
 		return
 	}
 }
@@ -620,10 +620,10 @@ func (siw *ServerInterfaceWrapper) GetHoles(w http.ResponseWriter, r *http.Reque
 	)
 
 	ctx := r.Context()
-	cw := uhttp.NewResponseWriter(w,
+	w = uhttp.NewResponseWriter(w,
 		uhttp.WithDefaultStatusCode(http.StatusOK),
 		uhttp.WithDefaultHeader(uhttp.HeaderRequestID, uhttp.RequestIDFromContext(ctx)),
-		uhttp.WithDefaultHeader(uhttp.HeaderContentType, uhttp.ContentTypeJSON),
+		uhttp.WithDefaultHeader(uhttp.HeaderContentType, "application/json; charset=utf-8"),
 	)
 
 	// ------------- Path parameter "marker_id" -------------
@@ -635,7 +635,7 @@ func (siw *ServerInterfaceWrapper) GetHoles(w http.ResponseWriter, r *http.Reque
 		&markerId,
 		runtime.BindStyledParameterOptions{Explode: false, Required: true},
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "marker_id", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "marker_id", Err: err})
 		return
 	}
 
@@ -651,7 +651,7 @@ func (siw *ServerInterfaceWrapper) GetHoles(w http.ResponseWriter, r *http.Reque
 		r.URL.Query(),
 		&params.Limit,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "limit", Err: err})
 		return
 	}
 
@@ -664,7 +664,7 @@ func (siw *ServerInterfaceWrapper) GetHoles(w http.ResponseWriter, r *http.Reque
 		r.URL.Query(),
 		&params.LastVal,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "last_val", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "last_val", Err: err})
 		return
 	}
 
@@ -677,7 +677,7 @@ func (siw *ServerInterfaceWrapper) GetHoles(w http.ResponseWriter, r *http.Reque
 		r.URL.Query(),
 		&params.LastId,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "last_id", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "last_id", Err: err})
 		return
 	}
 
@@ -690,7 +690,7 @@ func (siw *ServerInterfaceWrapper) GetHoles(w http.ResponseWriter, r *http.Reque
 		r.URL.Query(),
 		&params.Offset,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "offset", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "offset", Err: err})
 		return
 	}
 
@@ -703,7 +703,7 @@ func (siw *ServerInterfaceWrapper) GetHoles(w http.ResponseWriter, r *http.Reque
 		r.URL.Query(),
 		&params.SortBy,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "sort_by", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "sort_by", Err: err})
 		return
 	}
 
@@ -716,7 +716,7 @@ func (siw *ServerInterfaceWrapper) GetHoles(w http.ResponseWriter, r *http.Reque
 		r.URL.Query(),
 		&params.SortDir,
 	); err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "sort_dir", Err: err})
+		siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "sort_dir", Err: err})
 		return
 	}
 
@@ -741,7 +741,7 @@ func (siw *ServerInterfaceWrapper) GetHoles(w http.ResponseWriter, r *http.Reque
 	// Invoke the callback with all the unmarshalled arguments
 	resp, err := siw.handler.GetHoles(logging.LoggerWithComponent(l, "handler"), r, markerId, params)
 	if err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, err)
+		siw.errorHandlerFunc(ctx, l, w, err)
 		return
 	}
 
@@ -749,7 +749,7 @@ func (siw *ServerInterfaceWrapper) GetHoles(w http.ResponseWriter, r *http.Reque
 	w.WriteHeader(200)
 	err = json.NewEncoder(w).Encode(resp)
 	if err != nil {
-		siw.errorHandlerFunc(ctx, l, cw, err)
+		siw.errorHandlerFunc(ctx, l, w, err)
 		return
 	}
 }

--- a/pkg/apis/templates/gorilla/gorilla-middleware.tmpl
+++ b/pkg/apis/templates/gorilla/gorilla-middleware.tmpl
@@ -113,7 +113,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
   w = uhttp.NewResponseWriter(w,
     uhttp.WithDefaultStatusCode(http.StatusOK),
     uhttp.WithDefaultHeader(uhttp.HeaderRequestID, uhttp.RequestIDFromContext(ctx)),
-    uhttp.WithDefaultHeader(uhttp.HeaderContentType, "{{ $contentType }}; charset=utf-8"),
+    uhttp.WithDefaultHeader(uhttp.HeaderContentType, "application/json; charset=utf-8"),
   )
 
   {{range .PathParams}}// ------------- Path parameter "{{.ParamName}}" -------------

--- a/pkg/apis/templates/gorilla/gorilla-middleware.tmpl
+++ b/pkg/apis/templates/gorilla/gorilla-middleware.tmpl
@@ -110,10 +110,10 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
   )
 
   ctx := r.Context()
-  cw := uhttp.NewResponseWriter(w,
+  w = uhttp.NewResponseWriter(w,
     uhttp.WithDefaultStatusCode(http.StatusOK),
     uhttp.WithDefaultHeader(uhttp.HeaderRequestID, uhttp.RequestIDFromContext(ctx)),
-    uhttp.WithDefaultHeader(uhttp.HeaderContentType, uhttp.ContentTypeJSON),
+    uhttp.WithDefaultHeader(uhttp.HeaderContentType, "application/json; charset=utf-8"),
   )
 
   {{range .PathParams}}// ------------- Path parameter "{{.ParamName}}" -------------
@@ -122,7 +122,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
   {{- if .IsJson }}
   err = json.Unmarshal([]byte(mux.Vars(r)["{{.ParamName}}"]), &{{$varName}})
   if err != nil {
-    siw.errorHandlerFunc(ctx, l, cw, &UnmarshalingParamError{ParamName: "{{.ParamName}}", Err: err})
+    siw.errorHandlerFunc(ctx, l, w, &UnmarshalingParamError{ParamName: "{{.ParamName}}", Err: err})
     return
   }
   {{end}}
@@ -134,7 +134,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
      &{{$varName}},
      runtime.BindStyledParameterOptions{Explode: {{.Explode}}, Required: {{.Required}}},
   ); err != nil {
-    siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "{{.ParamName}}", Err: err})
+    siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "{{.ParamName}}", Err: err})
     return
   }
   {{end}}
@@ -159,14 +159,14 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
         {{if .IsJson}}
           value := new({{.TypeDef}})
           if err := json.Unmarshal([]byte(paramValue), value); err != nil {
-            siw.errorHandlerFunc(ctx, l, cw, &UnmarshalingParamError{ParamName: "{{.ParamName}}", Err: err})
+            siw.errorHandlerFunc(ctx, l, w, &UnmarshalingParamError{ParamName: "{{.ParamName}}", Err: err})
             return
           }
 
           params.{{.GoName}} = {{if not .Required}}&{{end}}value
         {{end}}
         }{{if .Required}} else {
-            siw.errorHandlerFunc(ctx, l, cw, &RequiredParamError{ParamName: "{{.ParamName}}"})
+            siw.errorHandlerFunc(ctx, l, w, &RequiredParamError{ParamName: "{{.ParamName}}"})
             return
         }{{end}}
       {{end}}
@@ -179,7 +179,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
         r.URL.Query(),
         &params.{{.GoName}},
       ); err != nil {
-        siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "{{.ParamName}}", Err: err})
+        siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "{{.ParamName}}", Err: err})
         return
       }
       {{end}}
@@ -193,7 +193,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           var {{.GoName}} {{.TypeDef}}
           n := len(valueList)
           if n != 1 {
-            siw.errorHandlerFunc(ctx, l, cw, &TooManyValuesForParamError{ParamName: "{{.ParamName}}", Count: n})
+            siw.errorHandlerFunc(ctx, l, w, &TooManyValuesForParamError{ParamName: "{{.ParamName}}", Count: n})
             return
           }
 
@@ -203,7 +203,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
 
         {{if .IsJson}}
           if err := json.Unmarshal([]byte(valueList[0]), &{{.GoName}}); err != nil {
-            siw.errorHandlerFunc(ctx, l, cw, &UnmarshalingParamError{ParamName: "{{.ParamName}}", Err: err})
+            siw.errorHandlerFunc(ctx, l, w, &UnmarshalingParamError{ParamName: "{{.ParamName}}", Err: err})
             return
           }
         {{end}}
@@ -211,7 +211,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
         {{if .IsStyled}}
           err = runtime.BindStyledParameterWithOptions("{{.Style}}", "{{.ParamName}}", valueList[0], &{{.GoName}}, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: {{.Explode}}, Required: {{.Required}}})
           if err != nil {
-            siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "{{.ParamName}}", Err: err})
+            siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "{{.ParamName}}", Err: err})
             return
           }
         {{end}}
@@ -220,7 +220,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
 
         } {{if .Required}}else {
             err = fmt.Errorf("Header parameter {{.ParamName}} is required, but not found")
-            siw.errorHandlerFunc(ctx, l, cw, &RequiredHeaderError{ParamName: "{{.ParamName}}", Err: err})
+            siw.errorHandlerFunc(ctx, l, w, &RequiredHeaderError{ParamName: "{{.ParamName}}", Err: err})
             return
         }{{end}}
 
@@ -242,12 +242,12 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
         decoded, err := url.QueryUnescape(cookie.Value)
         if err != nil {
           err = fmt.Errorf("Error unescaping cookie parameter '{{.ParamName}}': %w", err)
-          siw.errorHandlerFunc(ctx, l, cw, &UnescapedCookieParamError{ParamName: "{{.ParamName}}", Err: err})
+          siw.errorHandlerFunc(ctx, l, w, &UnescapedCookieParamError{ParamName: "{{.ParamName}}", Err: err})
           return
         }
 
         if err := json.Unmarshal([]byte(decoded), &value); err != nil {
-          siw.errorHandlerFunc(ctx, l, cw, &UnmarshalingParamError{ParamName: "{{.ParamName}}", Err: err})
+          siw.errorHandlerFunc(ctx, l, w, &UnmarshalingParamError{ParamName: "{{.ParamName}}", Err: err})
           return
         }
 
@@ -263,7 +263,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
             &value,
             runtime.BindStyledParameterOptions{Explode: {{.Explode}}, Required: {{.Required}}},
         ); err != nil {
-          siw.errorHandlerFunc(ctx, l, cw, &InvalidParamFormatError{ParamName: "{{.ParamName}}", Err: err})
+          siw.errorHandlerFunc(ctx, l, w, &InvalidParamFormatError{ParamName: "{{.ParamName}}", Err: err})
           return
         }
         params.{{.GoName}} = {{if not .Required}}&{{end}}value
@@ -271,7 +271,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
       }
 
       {{- if .Required}} else {
-        siw.errorHandlerFunc(ctx, l, cw, &RequiredParamError{ParamName: "{{.ParamName}}"})
+        siw.errorHandlerFunc(ctx, l, w, &RequiredParamError{ParamName: "{{.ParamName}}"})
         return
       }
       {{- end}}
@@ -285,10 +285,10 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
     // ------------- Body parameter for {{$opid}} for {{$contentType}} ContentType -------------
     jsonBody := new({{.TypeName}})
     if err := siw.parseRequestBody(r, jsonBody); err != nil {
-        siw.errorHandlerFunc(ctx, l, cw, err)
+        siw.errorHandlerFunc(ctx, l, w, err)
         return
     } else if jsonBody == nil {
-        siw.errorHandlerFunc(ctx, l, cw, &UnmarshalingBodyError{Err: errors.New("empty body")})
+        siw.errorHandlerFunc(ctx, l, w, &UnmarshalingBodyError{Err: errors.New("empty body")})
         return
     }
 
@@ -302,7 +302,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
     }
 
     if err := siw.parseRequestBody(r, body.File); err != nil {
-        siw.errorHandlerFunc(ctx, l, cw, err)
+        siw.errorHandlerFunc(ctx, l, w, err)
         return
     }
   {{end}}
@@ -310,13 +310,13 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
 
   {{ if .Spec.Security }}
   if siw.authz == nil {
-    siw.errorHandlerFunc(ctx, l, cw, errors.New("authorization middleware not set"))
+    siw.errorHandlerFunc(ctx, l, w, errors.New("authorization middleware not set"))
     return
   }
 
   _, err := siw.authz.{{$opid}}(logging.LoggerWithComponent(l, "auth"), r{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}}{{if gt (len .Bodies) 0}}, body{{end}})
   if err != nil {
-    siw.errorHandlerFunc(ctx, l, cw, err)
+    siw.errorHandlerFunc(ctx, l, w, err)
     return
   }
   {{ end }}
@@ -342,7 +342,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
   // Invoke the callback with all the unmarshalled arguments
   resp, err := siw.handler.{{$opid}}(logging.LoggerWithComponent(l, "handler"), r{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}}{{if gt (len .Bodies) 0}}, body{{end}}{{$form}})
   if err != nil {
-    siw.errorHandlerFunc(ctx, l, cw, err)
+    siw.errorHandlerFunc(ctx, l, w, err)
     return
   }
 
@@ -377,7 +377,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
   {{ end -}}
   {{- end }}
   if err != nil {
-    siw.errorHandlerFunc(ctx, l, cw, err)
+    siw.errorHandlerFunc(ctx, l, w, err)
     return
   }
 }

--- a/pkg/apis/templates/gorilla/gorilla-middleware.tmpl
+++ b/pkg/apis/templates/gorilla/gorilla-middleware.tmpl
@@ -113,7 +113,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
   w = uhttp.NewResponseWriter(w,
     uhttp.WithDefaultStatusCode(http.StatusOK),
     uhttp.WithDefaultHeader(uhttp.HeaderRequestID, uhttp.RequestIDFromContext(ctx)),
-    uhttp.WithDefaultHeader(uhttp.HeaderContentType, "application/json; charset=utf-8"),
+    uhttp.WithDefaultHeader(uhttp.HeaderContentType, "{{ $contentType }}; charset=utf-8"),
   )
 
   {{range .PathParams}}// ------------- Path parameter "{{.ParamName}}" -------------


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request makes several changes to the `ServerInterfaceWrapper` methods in the `pkg/apis/specs/api/server.go` file. The primary focus is on simplifying the handling of HTTP responses by replacing the custom `cw` variable with the standard `w` variable throughout the code.

### Simplification of HTTP response handling:

* Updated `GetClubs` method to replace the `cw` variable with `w` for handling HTTP responses. [[1]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L197-R200) [[2]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L215-R215) [[3]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L228-R228) [[4]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L241-R241) [[5]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L254-R254) [[6]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L267-R267) [[7]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L280-R280) [[8]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L293-R293) [[9]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L318-R326)
* Updated `GetCourses` method to replace the `cw` variable with `w` for handling HTTP responses. [[1]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L339-R342) [[2]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L354-R354) [[3]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L370-R370) [[4]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L383-R383) [[5]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L396-R396) [[6]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L409-R409) [[7]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L422-R422) [[8]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L435-R435) [[9]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L460-R468)
* Updated `GetMarkers` method to replace the `cw` variable with `w` for handling HTTP responses. [[1]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L481-R484) [[2]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L496-R496) [[3]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L512-R512) [[4]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L525-R525) [[5]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L538-R538) [[6]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L551-R551) [[7]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L564-R564) [[8]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L577-R577) [[9]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L602-R610)
* Updated `GetHoles` method to replace the `cw` variable with `w` for handling HTTP responses. [[1]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L623-R626) [[2]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L638-R638) [[3]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L654-R654) [[4]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L667-R667) [[5]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L680-R680) [[6]](diffhunk://#diff-d932f5574c0d67ad85d5b58a2439df2a7ad9784f5637186108ce1adf0de762a7L693-R693)

These changes ensure consistency in the codebase and simplify the handling of HTTP responses across different methods.