### PR TITLE
feat(api): allowing the correct rate of requests

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -47,7 +47,7 @@ func main() {
 			dom := domain.NewDomain(svcRepo)
 			svc := apiSvc.NewService(dom)
 
-			rateLimiter := uhttp.NewRedisRateLimiter(a.RedisPool(), 1, 5,
+			rateLimiter := uhttp.NewRedisRateLimiter(a.RedisPool(), 10, 25,
 				uhttp.WithLogger(logging.LoggerWithComponent(l, "rate-limiter")),
 			)
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a change to the rate limiter configuration in the `cmd/api/main.go` file. The change adjusts the rate limits to allow for higher throughput.

Rate limiter configuration change:

* [`cmd/api/main.go`](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL50-R50): Increased the rate limiter settings from 1 request per second with a burst of 5 to 10 requests per second with a burst of 25.